### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/functions/git/vcs.git.present.fish
+++ b/functions/git/vcs.git.present.fish
@@ -1,5 +1,5 @@
 function vcs.git.present
-  available git; or return 1
+  type -q git; or return 1
 
   test -d .git;
     or command git rev-parse --git-dir >/dev/null ^&1

--- a/functions/hg/vcs.hg.present.fish
+++ b/functions/hg/vcs.hg.present.fish
@@ -1,5 +1,5 @@
 function vcs.hg.present
-  available hg; or return 1
+  type -q hg; or return 1
   test -d .hg; and return 0
   set -l dir $PWD
 

--- a/functions/svn/vcs.svn.present.fish
+++ b/functions/svn/vcs.svn.present.fish
@@ -1,4 +1,4 @@
 function vcs.svn.present
-  available svn; or return 1
+  type -q svn; or return 1
   command svn info >/dev/null ^&1
 end


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
