### PR TITLE
Add conflict detection functions

### DIFF
--- a/functions/git/vcs.conflict.fish
+++ b/functions/git/vcs.conflict.fish
@@ -1,0 +1,10 @@
+function vcs.conflict
+  set -l dot_git_path (git rev-parse --git-dir)
+  if test -d $dot_git_path/rebase-apply
+    echo -n 'rebase'
+    return
+  # Another option is to list the unmerged files with: git ls-files -u
+  else if not command git merge HEAD >/dev/null 2>&1
+    echo -n 'merge'
+  end
+end

--- a/functions/hg/vcs.conflict.fish
+++ b/functions/hg/vcs.conflict.fish
@@ -1,0 +1,3 @@
+function vcs.conflict
+  contains 'U' (command  hg resolve --list ^/dev/null | cut -c1 | sort -u)
+end

--- a/functions/svn/vcs.conflict.fish
+++ b/functions/svn/vcs.conflict.fish
@@ -1,0 +1,3 @@
+function vcs.conflict
+  contains 'C' (command svn status ^/dev/null | cut -c1 | sort -u)
+end


### PR DESCRIPTION
These can be useful if one wants to display "branch|rebase" info in the prompt.