### PR TITLE
Two fixes for fish 3

### DIFF
--- a/functions/git/vcs.branch.fish
+++ b/functions/git/vcs.branch.fish
@@ -1,4 +1,4 @@
 function vcs.branch
-  command git symbolic-ref --short HEAD ^/dev/null;
-    or command git show-ref --head -s --abbrev | head -n1 ^/dev/null
+  command git symbolic-ref --short HEAD 2>/dev/null;
+    or command git show-ref --head -s --abbrev | head -n1 2>/dev/null
 end

--- a/functions/git/vcs.dirty.fish
+++ b/functions/git/vcs.dirty.fish
@@ -1,3 +1,3 @@
 function vcs.dirty -d "Check if there are changes to tracked files"
-  not command git diff --no-ext-diff --quiet --exit-code ^/dev/null
+  not command git diff --no-ext-diff --quiet --exit-code 2>/dev/null
 end

--- a/functions/git/vcs.git.present.fish
+++ b/functions/git/vcs.git.present.fish
@@ -9,7 +9,7 @@ function vcs.git.present
       and grep -q gitdir $dir'/.git'
       and return 0
     # Go up one directory
-    set -l dir (dirname $dir 2>/dev/null)
+    set dir (dirname $dir 2>/dev/null)
   end
 
   return 1

--- a/functions/git/vcs.git.present.fish
+++ b/functions/git/vcs.git.present.fish
@@ -9,7 +9,7 @@ function vcs.git.present
       and grep -q gitdir $dir'/.git'
       and return 0
     # Go up one directory
-    set -l dir (dirname $dir ^/dev/null)
+    set -l dir (dirname $dir 2>/dev/null)
   end
 
   return 1

--- a/functions/git/vcs.root.fish
+++ b/functions/git/vcs.root.fish
@@ -1,3 +1,3 @@
 function vcs.root
-  command git rev-parse --show-toplevel ^/dev/null
+  command git rev-parse --show-toplevel 2>/dev/null
 end

--- a/functions/git/vcs.stashed.fish
+++ b/functions/git/vcs.stashed.fish
@@ -1,3 +1,3 @@
 function vcs.stashed
-  command git rev-parse --verify --quiet refs/stash ^/dev/null
+  command git rev-parse --verify --quiet refs/stash 2>/dev/null
 end

--- a/functions/git/vcs.status.fish
+++ b/functions/git/vcs.status.fish
@@ -5,10 +5,10 @@ function vcs.status -a ahead behind diverged detached clean
   test -z "$detached"; and set detached "detached"
   test -z "$clean";    and set clean    "clean"
 
-  set revs (command git rev-list --count --left-right "@{upstream}...HEAD" ^/dev/null)
+  set revs (command git rev-list --count --left-right "@{upstream}...HEAD" 2>/dev/null)
 
   if test "$status" -ne 0
-    if not command git symbolic-ref --short HEAD >/dev/null ^&1
+    if not command git symbolic-ref --short HEAD >/dev/null 2>&1
       echo "$detached"
       return
     end

--- a/functions/git/vcs.touched.fish
+++ b/functions/git/vcs.touched.fish
@@ -1,3 +1,3 @@
 function vcs.touched
-  test -n (echo (command git status --porcelain ^/dev/null))
+  test -n (echo (command git status --porcelain 2>/dev/null))
 end

--- a/functions/hg/vcs.branch.fish
+++ b/functions/hg/vcs.branch.fish
@@ -1,4 +1,4 @@
 function vcs.branch
-  cat (vcs.root)/.hg/branch ^/dev/null;
+  cat (vcs.root)/.hg/branch 2>/dev/null;
     or echo "default"
 end

--- a/functions/hg/vcs.conflict.fish
+++ b/functions/hg/vcs.conflict.fish
@@ -1,3 +1,3 @@
 function vcs.conflict
-  contains 'U' (command  hg resolve --list ^/dev/null | cut -c1 | sort -u)
+  contains 'U' (command  hg resolve --list 2>/dev/null | cut -c1 | sort -u)
 end

--- a/functions/hg/vcs.dirty.fish
+++ b/functions/hg/vcs.dirty.fish
@@ -1,3 +1,3 @@
 function vcs.dirty
-  command hg summary ^/dev/null | command grep -q 'commit: (clean)' ^/dev/null
+  command hg summary 2>/dev/null | command grep -q 'commit: (clean)' ^/dev/null
 end

--- a/functions/hg/vcs.hg.present.fish
+++ b/functions/hg/vcs.hg.present.fish
@@ -6,7 +6,7 @@ function vcs.hg.present
   while test "$dir" != "/"
     test -d $dir'/.hg'; and return 0
     # Go up one directory
-    set -l dir (dirname $dir ^/dev/null)
+    set -l dir (dirname $dir 2>/dev/null)
   end
 
   return 1

--- a/functions/hg/vcs.hg.present.fish
+++ b/functions/hg/vcs.hg.present.fish
@@ -6,7 +6,7 @@ function vcs.hg.present
   while test "$dir" != "/"
     test -d $dir'/.hg'; and return 0
     # Go up one directory
-    set -l dir (dirname $dir 2>/dev/null)
+    set dir (dirname $dir 2>/dev/null)
   end
 
   return 1

--- a/functions/hg/vcs.root.fish
+++ b/functions/hg/vcs.root.fish
@@ -8,7 +8,7 @@ function vcs.root
     end
 
     # Go up one directory
-    set -l dir (dirname $dir ^/dev/null)
+    set -l dir (dirname $dir 2>/dev/null)
   end
 
   return 1

--- a/functions/hg/vcs.staged.fish
+++ b/functions/hg/vcs.staged.fish
@@ -1,3 +1,3 @@
 function vcs.staged
-  contains 'M' (command hg status ^/dev/null | cut -d' ' -f1 | sort -u)
+  contains 'M' (command hg status 2>/dev/null | cut -d' ' -f1 | sort -u)
 end

--- a/functions/hg/vcs.stashed.fish
+++ b/functions/hg/vcs.stashed.fish
@@ -1,3 +1,3 @@
 function vcs.stashed
-  count (command hg shelve --list ^/dev/null) >/dev/null
+  count (command hg shelve --list 2>/dev/null) >/dev/null
 end

--- a/functions/hg/vcs.touched.fish
+++ b/functions/hg/vcs.touched.fish
@@ -1,3 +1,3 @@
 function vcs.touched
-  test -n (echo (command hg status ^/dev/null))
+  test -n (echo (command hg status 2>/dev/null))
 end

--- a/functions/svn/vcs.conflict.fish
+++ b/functions/svn/vcs.conflict.fish
@@ -1,3 +1,3 @@
 function vcs.conflict
-  contains 'C' (command svn status ^/dev/null | cut -c1 | sort -u)
+  contains 'C' (command svn status 2>/dev/null | cut -c1 | sort -u)
 end

--- a/functions/svn/vcs.dirty.fish
+++ b/functions/svn/vcs.dirty.fish
@@ -1,3 +1,3 @@
 function vcs.dirty
-  count (command svn status -q ^/dev/null) >/dev/null
+  count (command svn status -q 2>/dev/null) >/dev/null
 end

--- a/functions/svn/vcs.root.fish
+++ b/functions/svn/vcs.root.fish
@@ -1,3 +1,3 @@
 function vcs.root
-  command svn info --show-item wc-root ^/dev/null
+  command svn info --show-item wc-root 2>/dev/null
 end

--- a/functions/svn/vcs.staged.fish
+++ b/functions/svn/vcs.staged.fish
@@ -1,3 +1,3 @@
 function vcs.staged
-  contains 'M' (command svn status ^/dev/null | cut -c1 | sort -u)
+  contains 'M' (command svn status 2>/dev/null | cut -c1 | sort -u)
 end

--- a/functions/svn/vcs.svn.present.fish
+++ b/functions/svn/vcs.svn.present.fish
@@ -1,4 +1,4 @@
 function vcs.svn.present
   type -q svn; or return 1
-  command svn info >/dev/null ^&1
+  command svn info >/dev/null 2>&1
 end

--- a/functions/svn/vcs.touched.fish
+++ b/functions/svn/vcs.touched.fish
@@ -1,3 +1,3 @@
 function vcs.touched
-  count (command svn status ^/dev/null | grep -Ev 'Performing|$\s*^' | cut -c1) >/dev/null ^&1
+  count (command svn status 2>/dev/null | grep -Ev 'Performing|$\s*^' | cut -c1) >/dev/null ^&1
 end


### PR DESCRIPTION
After upgrading my local fish version to the newly released fish 3, it became very hard and slow to get a terminal up and running.
There are certain breaking changes when moving from v2.7.1 to v3, and turns out that the `vcs` plugin, which powers many of OMF's themes, easily gets stuck in an infinite loop whenever stepping outside of a root of a hg/git local repository.

The first commit deals with the deprecation of `^` as stderr redirection and the second one deals with changes to how variable scoping works in a `while` loop.