### PR TITLE
Fix vcs.root.fish for hg

### DIFF
--- a/functions/hg/vcs.root.fish
+++ b/functions/hg/vcs.root.fish
@@ -8,7 +8,7 @@ function vcs.root
     end
 
     # Go up one directory
-    set -l dir (dirname $dir 2>/dev/null)
+    set dir (dirname $dir 2>/dev/null)
   end
 
   return 1


### PR DESCRIPTION
I just upgraded to fish 3.0 and noticed that on hg repositories, fish would hang because I'm showing the vcs status in my prompt, which requires `vcs.root` to work. This change fixes it.