### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/hg/vcs.dirty.fish
+++ b/functions/hg/vcs.dirty.fish
@@ -1,3 +1,3 @@
 function vcs.dirty
-  command hg summary 2>/dev/null | command grep -q 'commit: (clean)' ^/dev/null
+  command hg summary 2> /dev/null | command grep -q 'commit: (clean)' 2> /dev/null
 end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618