### PR TITLE
git/vcs.touched: Speed up

### DIFF
--- a/functions/git/vcs.touched.fish
+++ b/functions/git/vcs.touched.fish
@@ -1,3 +1,4 @@
 function vcs.touched
-  test -n (echo (command git status --porcelain 2>/dev/null))
+  not command git diff-index --cached --quiet HEAD -- >/dev/null 2>&1
+  or not command git diff --no-ext-diff --quiet --exit-code >/dev/null 2>&1
 end


### PR DESCRIPTION
`git status --porcelain` does everything, which turns out to be quite
slow.

See oh-my-fish/#624.