### PR TITLE
Adds logic to find the correct vcs path

### DIFF
--- a/conf.d/plugin-vcs.fish
+++ b/conf.d/plugin-vcs.fish
@@ -1,4 +1,10 @@
-set -l vcs_path (dirname (dirname $conf_path))
+# conf_path is passed in as an array from `require --path`
+for conf in $conf_path
+  if echo $conf | grep -q 'vcs'
+    # setting function scoped as local scoped means it is local to the if block
+    set -f vcs_path (dirname (dirname $conf))
+  end
+end
 
 for vcs in git hg svn
   source $vcs_path/functions/$vcs/vcs.$vcs.present.fish


### PR DESCRIPTION
More of a PRFC than an actual PR. I'm not super familiar with omf and fish, so I'm flying by the seat of my pants. This broke for me today because `$conf_path` was being passed in as an array, so `$vcs_path` was automatically being set to the first element of the array, which in my case was not the vcs path, but something else based on my plugin installations (and probably the order in which the directories are [traversed by fish](https://github.com/oh-my-fish/oh-my-fish/blob/90f875e02dbb63a7e12430ceb034206bea278c28/init.fish#L24)).

Happy to make adjustments if you have a better strategy for selecting the correct directory, or maybe something is messed up in my installation and I just need to tear it down and reinstall :shrug:.

Signed-off-by: Michael Stergianis <mstergianis@vmware.com>